### PR TITLE
Filter instruments by exchange and also by segment

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -737,11 +737,11 @@ regular).
                 "exchange": exchange
             }, null, transformInstrumentsResponse);
         } else if (exchange && segment ) {
-	    return _get("market.instruments", {
+            return _get("market.instruments", {
                 "exchange": exchange,
-		"segment": segment
+                "segment": segment
             }, null, transformInstrumentsResponse);
-	} else {
+        } else {
             return _get("market.instruments.all", null, null, transformInstrumentsResponse);
         }
     };

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -731,12 +731,17 @@ regular).
      * @param {Array} [segment] Filter instruments based on exchange (NSE, BSE, NFO, BFO, CDS, MCX).
      * If no `segment` is specified, all instruments are returned.
      */
-    self.getInstruments = function(exchange) {
-        if(exchange) {
+    self.getInstruments = function(exchange, segment) {
+        if(exchange && !segment) {
             return _get("market.instruments", {
                 "exchange": exchange
             }, null, transformInstrumentsResponse);
-        } else {
+        } else if (exchange && segment ) {
+	    return _get("market.instruments", {
+                "exchange": exchange,
+		"segment": segment
+            }, null, transformInstrumentsResponse);
+	} else {
             return _get("market.instruments.all", null, null, transformInstrumentsResponse);
         }
     };


### PR DESCRIPTION
**Changelog:**
 - Added an extra argument to getInstruments function to filter by "exhange" and also by "segment".

 - This change is required due to getInstruments response being too big and many traders do not need all the instruments data.

@vividvilla @sivamgr Please review this and merge the code.