### PR TITLE
typo in jsdoc

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -769,7 +769,7 @@ regular).
      * @method getQuote
      * @memberOf KiteConnect
      * @instance
-     * @param {Array} instruments is a list of instruments, Instrument are in the format of `tradingsymbol:exchange`.
+     * @param {Array} instruments is a list of instruments, Instrument are in the format of `exchange:tradingsymbol`.
      * 	For example NSE:INFY
      */
     self.getQuote = function(instruments) {


### PR DESCRIPTION
while fetching the quote for the array of instruments, instruments should be in format `exchange:tradingsymbol`