### PR TITLE
Review

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -222,166 +222,176 @@ var KiteConnect = function(params) {
     // Constants
     // Products
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.PRODUCT_MIS = "MIS";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.PRODUCT_CNC = "CNC";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.PRODUCT_NRML = "NRML";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.PRODUCT_CO = "CO";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.PRODUCT_BO = "BO";
 
     // Order types
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.ORDER_TYPE_MARKET = "MARKET";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.ORDER_TYPE_LIMIT = "LIMIT";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.ORDER_TYPE_SLM = "SL-M";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.ORDER_TYPE_SL = "SL";
 
     // Varities
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.VARIETY_REGULAR = "regular";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.VARIETY_BO = "bo";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.VARIETY_CO = "co";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.VARIETY_AMO = "amo";
 
     // Transaction type
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.TRANSACTION_TYPE_BUY = "BUY";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.TRANSACTION_TYPE_SELL = "SELL";
 
     // Validity
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.VALIDITY_DAY = "DAY";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.VALIDITY_IOC = "IOC";
 
     // Exchanges
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.EXCHANGE_NSE = "NSE";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.EXCHANGE_BSE = "BSE";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.EXCHANGE_NFO = "NFO";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.EXCHANGE_CDS = "CDS";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.EXCHANGE_BFO = "BFO";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.EXCHANGE_MCX = "MCX";
 
     // Margins segments
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.MARGIN_EQUITY = "equity";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.MARGIN_COMMODITY = "commodity";
 
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.STATUS_CANCELLED = "CANCELLED";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.STATUS_REJECTED = "REJECTED";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.STATUS_COMPLETE = "COMPLETE";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.GTT_TYPE_OCO = "two-leg";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
     self.GTT_TYPE_SINGLE = "single";
 	/**
-	* @memberOf KiteTicker
+	* @memberOf KiteConnect
 	*/
 	self.GTT_STATUS_ACTIVE = "active";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
 	self.GTT_STATUS_TRIGGERED = "triggered";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
 	self.GTT_STATUS_DISABLED = "disabled";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
 	self.GTT_STATUS_EXPIRED = "expired";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
 	self.GTT_STATUS_CANCELLED = "cancelled";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
 	self.GTT_STATUS_REJECTED = "rejected";
     /**
-    * @memberOf KiteTicker
+    * @memberOf KiteConnect
     */
 	self.GTT_STATUS_DELETED = "deleted";
+
+    /**
+    * @memberOf KiteConnect
+    */
+	self.POSITION_TYPE_DAY = "day";
+
+    /**
+    * @memberOf KiteConnect
+    */
+	self.POSITION_TYPE_OVERNIGHT = "overnight";
 
     /**
     * Set `access_token` received after a successful authentication.

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -565,6 +565,7 @@ var KiteConnect = function(params) {
      * @param {number} [params.squareoff] Square off value (only for bracket orders)
      * @param {number} [params.stoploss] Stoploss value (only for bracket orders)
      * @param {number} [params.trailing_stoploss] Trailing stoploss value (only for bracket orders)
+     * @param {string} [params.tag] An optional tag to apply to an order to identify it (alphanumeric, max 20 chars)
      */
     self.placeOrder = function (variety, params) {
         params.variety = variety;
@@ -928,7 +929,7 @@ regular).
      * @param {string} params.transaction_type Transaction type (BUY or SELL).
      * @param {string} [params.quantity] Quantity to SELL. Not applicable on BUYs.
      * @param {string} [params.amount] Amount worth of units to purchase. Not applicable on SELLs
-     * @param {string} [params.tag] An optional tag to apply to an order to identify it (alphanumeric, max 8 chars)
+     * @param {string} [params.tag] An optional tag to apply to an order to identify it (alphanumeric, max 20 chars)
      */
     self.placeMFOrder = function (params) {
         return _post("mf.order.place", params);
@@ -972,7 +973,7 @@ regular).
      * @param {string} params.frequency Order frequency. weekly, monthly, or quarterly.
      * @param {string} [params.initial_amount] Amount worth of units to purchase before the SIP starts.
      * @param {string} [params.instalment_day] If frequency is monthly, the day of the month (1, 5, 10, 15, 20, 25) to trigger the order on.
-     * @param {string} [params.tag] An optional tag to apply to an order to identify it (alphanumeric, max 8 chars).
+     * @param {string} [params.tag] An optional tag to apply to an order to identify it (alphanumeric, max 20 chars)
      */
     self.placeMFSIP = function (params) {
         return _post("mf.sip.place", params);

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1244,7 +1244,7 @@ regular).
         return data;
     }
 
-    function parseHistorical(jsonData, headers) {
+    function parseHistorical(jsonData) {
         // Return if its an error
         if (jsonData.error_type) return jsonData;
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -664,7 +664,7 @@ regular).
      * @memberOf KiteConnect
      * @instance
      */
-    self.getTrades = function(order_id) {
+    self.getTrades = function() {
         return _get("trades", null, null, formatResponse);
     };
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -609,7 +609,7 @@ var KiteConnect = function(params) {
      * @method cancelOrder
      * @memberOf KiteConnect
      * @instance
-     * @param {string} variety Order variety (ex. bo, co, amo,
+     * @param {string} variety Order variety (ex. bo, co, amo)
      * @param {string} order_id ID of the order.
      * @param {Object} [params] Order params.
 regular).
@@ -627,10 +627,9 @@ regular).
      * @method exitOrder
      * @memberOf KiteConnect
      * @instance
-     * @param {string} variety Order variety (ex. bo, co, amo,
+     * @param {string} variety Order variety (ex. bo, co, amo)
      * @param {string} order_id ID of the order.
      * @param {Object} [params] Order params.
-regular).
      * @param {string} [params.parent_order_id] Parent order id incase of multilegged orders.
      */
     self.exitOrder = function (variety, order_id, params) {
@@ -953,7 +952,7 @@ regular).
      * @param {string} order_id ID of the order.
      */
     self.cancelMFOrder = function (order_id) {
-        return _delete("mf.order.cancel", params)
+        return _delete("mf.order.cancel", { "order_id": order_id })
     }
 
     /**


### PR DESCRIPTION
I will be pushing here all fixes, as I encounter during the review for the new release.

- Include tag param on placeOrder comment block
- Add global constants for the position type conversion
- Remove un-required `order_id` param from the complete trade book. 
- Pass order_id as url argument for `cancelMFOrder` function
- Remove un-used headers from `parseHistorical`

PS: Not converting [new Date()](https://github.com/zerodha/kiteconnectjs/blob/6ae295085a5d90a4d053f5b65bf17e0cf64d0782/lib/connect.js#L1245) object (which currently returns date object in UTC) to local timezone(IST), as many users would have already discounted this and build time diff at their end. If we have to do this anyhow for better readability, then we will have to consider announcing this before head to users.
My suggestion is in favour of just maintaining a note of this in README, something like:
Note: [Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) by default timezone is always zero UTC offset, as denoted by the suffix "Z". If you want time string in your local time zone, you can convert using [toLocaleString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString).