### PR TITLE
feat: update ticker_attributes naming as per API doc

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -133,7 +133,6 @@ var KiteConnect = function(params) {
 
         "market.instruments.all": "/instruments",
         "market.instruments": "/instruments/{exchange}",
-        "market.margins": "/margins/{segment}",
         "market.historical": "/instruments/historical/{instrument_token}/{interval}",
         "market.trigger_range": "/instruments/trigger_range/{transaction_type}",
 
@@ -316,11 +315,7 @@ var KiteConnect = function(params) {
     */
     self.EXCHANGE_CDS = "CDS";
     /**
-    * @memberOf KiteConnect
-    */
-    self.EXCHANGE_BCD = "BCD";
-    /**
-     * @memberof KiteConnect
+    * @memberof KiteConnect
     */
     self.EXCHANGE_BFO = "BFO";
     /**
@@ -840,16 +835,6 @@ regular).
         return _get("market.quote.ltp", {"i": instruments});
     };
 
-    // /**
-    //  * Retrieve margins provided for individual segments.
-    //  * @method getInstrumentsMargins
-    //  * @memberOf KiteConnect
-    //  * @instance
-    //  * @param {string} segment is segment name to retrieve. For example equity, commodity
-    //  */
-    // self.getInstrumentsMargins = function(segment) {
-    //     return self._get("market.margins", {"segment": segment});
-    // };
 
     /**
      * Retrieve historical data (candles) for an instrument.

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -318,6 +318,10 @@ var KiteConnect = function(params) {
     /**
     * @memberOf KiteConnect
     */
+    self.EXCHANGE_BCD = "BCD";
+    /**
+     * @memberof KiteConnect
+    */
     self.EXCHANGE_BFO = "BFO";
     /**
     * @memberOf KiteConnect

--- a/lib/ticker.js
+++ b/lib/ticker.js
@@ -540,9 +540,9 @@ var KiteTicker = function(params) {
 
                 // Full mode with timestamp in seconds
                 if (bin.byteLength === 32) {
-					tick.timestamp = null;
+					tick.exchange_timestamp = null;
 					var timestamp = buf2long(bin.slice(28, 32));
-					if (timestamp) tick.timestamp = new Date(timestamp * 1000);
+					if (timestamp) tick.exchange_timestamp = new Date(timestamp * 1000);
 				}
 
 				ticks.push(tick);
@@ -555,11 +555,11 @@ var KiteTicker = function(params) {
                     mode: mode,
                     instrument_token: instrument_token,
                     last_price: buf2long(bin.slice(4, 8)) / divisor,
-                    last_quantity: buf2long(bin.slice(8, 12)),
-                    average_price: buf2long(bin.slice(12, 16)) / divisor,
-                    volume: buf2long(bin.slice(16, 20)),
-                    buy_quantity: buf2long(bin.slice(20, 24)),
-                    sell_quantity: buf2long(bin.slice(24, 28)),
+                    last_traded_quantity: buf2long(bin.slice(8, 12)),
+                    average_traded_price: buf2long(bin.slice(12, 16)) / divisor,
+                    volume_traded: buf2long(bin.slice(16, 20)),
+                    total_buy_quantity: buf2long(bin.slice(20, 24)),
+                    total_sell_quantity: buf2long(bin.slice(24, 28)),
                     ohlc: {
                         open: buf2long(bin.slice(28, 32)) / divisor,
                         high: buf2long(bin.slice(32, 36)) / divisor,
@@ -581,9 +581,9 @@ var KiteTicker = function(params) {
 					if (last_trade_time) tick.last_trade_time = new Date(last_trade_time * 1000);
 
 					// Parse timestamp
-					tick.timestamp = null;
+					tick.exchange_timestamp = null;
 					var timestamp = buf2long(bin.slice(60, 64));
-					if (timestamp) tick.timestamp = new Date(timestamp * 1000);
+					if (timestamp) tick.exchange_timestamp = new Date(timestamp * 1000);
 
 					// Parse OI
 					tick.oi = buf2long(bin.slice(48, 52));


### PR DESCRIPTION
Change ticker response attributes naming as per [kite connect doc](https://kite.trade/docs/connect/v3/websocket/#quote-packet-structure). 