### PR TITLE
fix: update kite version passed in headers

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -92,7 +92,7 @@ var KiteConnect = function(params) {
     self.default_login_uri = defaults.login;
     self.session_expiry_hook = null;
 
-      var kiteVersion = 3; // Kite version to send in header
+      var kiteVersion = 4; // Kite version to send in header
       var userAgent = utils.getUserAgent();  // User agent to be sent with every request
 
     var routes = {


### PR DESCRIPTION
This is to match the latest published version of the APIs.