### PR TITLE
fix(examples/connect): declare kc (kiteconnect client) with let and shorten expression in `ticker.js`

### DIFF
--- a/examples/connect.js
+++ b/examples/connect.js
@@ -10,7 +10,7 @@ var options = {
 	"debug": false
 };
 
-kc = new KiteConnect(options);
+let  kc = new KiteConnect(options);
 kc.setSessionExpiryHook(sessionHook);
 
 if(!access_token) {

--- a/lib/ticker.js
+++ b/lib/ticker.js
@@ -450,7 +450,7 @@ var KiteTicker = function(params) {
 	}
 
 	function autoReconnect(t, max_retry, max_delay) {
-		auto_reconnect = (t == true ? true : false);
+		auto_reconnect = (t == true);
 
 		// Set default values
 		max_retry = max_retry || defaultReconnectMaxRetries;


### PR DESCRIPTION
not declaring variables with `let/var/const` can lead to an error (kc is not defied in ES6+).
and `t == true` will return boolean value always without using any ternary operator `?`. 