### PR TITLE
feat: add getAuctionInstruments, variety in place order, auction tests and update submodule

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -115,6 +115,7 @@ var KiteConnect = function(params) {
 
         "portfolio.positions": "/portfolio/positions",
         "portfolio.holdings": "/portfolio/holdings",
+        "portfolio.holdings.auction": "/portfolio/holdings/auctions",
         "portfolio.positions.convert": "/portfolio/positions",
 
         "mf.orders": "/mf/orders",
@@ -280,6 +281,11 @@ var KiteConnect = function(params) {
     * @memberOf KiteConnect
     */
     self.VARIETY_ICEBERG = "iceberg";
+
+    /**
+    * @memberOf KiteConnect
+    */
+     self.VARIETY_AUCTION = "auction";
 
     // Transaction type
     /**
@@ -578,7 +584,7 @@ var KiteConnect = function(params) {
      * @param {string} params.transaction_type Transaction type (BUY or SELL).
      * @param {number} params.quantity Order quantity
      * @param {string} params.product	Product code (NRML, MIS, CNC).
-     * @param {string} params.order_type Order type (NRML, SL, SL-M, MARKET).
+     * @param {string} params.order_type Order type (LIMIT, SL, SL-M, MARKET).
      * @param {string} [params.validity] Order validity (DAY, IOC).
      * @param {number} [params.price] Order Price
      * @param {number} [params.disclosed_quantity] Disclosed quantity
@@ -589,6 +595,7 @@ var KiteConnect = function(params) {
      * @param {number} [params.validity_ttl] Order validity in minutes for TTL validity orders
      * @param {number} [params.iceberg_legs] Total number of legs for iceberg order variety
      * @param {number} [params.iceberg_quantity] Split quantity for each iceberg leg order
+     * @param {number} [params.auction_number] A unique identifier for a particular auction
      * @param {string} [params.tag] An optional tag to apply to an order to identify it (alphanumeric, max 20 chars)
      */
     self.placeOrder = function (variety, params) {
@@ -748,6 +755,16 @@ regular).
     self.getHoldings = function() {
         return _get("portfolio.holdings");
     };
+
+    /**
+     * Retrieves list of available instruments for a auction session.
+     * @method getAuctionInstruments
+     * @memberOf KiteConnect
+     * @instance
+     */
+    self.getAuctionInstruments = function() {
+        return _get("portfolio.holdings.auction");
+    }
 
     /**
      * Retrieve positions.

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,10 @@ function testSuite(){
       .get("/portfolio/holdings")
       .reply(200, parseJson("holdings.json"))
 
+      // getHoldings
+      .get("/portfolio/holdings/auctions")
+      .reply(200, parseJson("auctions_list.json"))
+
       // getPositions
       .get("/portfolio/positions")
       .reply(200, parseJson("positions.json"))
@@ -305,6 +309,20 @@ function testSuite(){
                 expect(response).to.be.an("array");
                 expect(response).to.have.nested.property("[0].tradingsymbol");
                 expect(response).to.have.nested.property("[0].average_price");
+                return done();
+            }).catch(done); 
+        })
+    });
+
+    // Retrieves list of available instruments for a auction session
+    describe("getAuctionInstruments", function() {
+        it("Retrieves list of available instruments for a auction session", (done) => {
+            kc.getAuctionInstruments()
+            .then(function(response) {
+                expect(response).to.be.an("array");
+                expect(response).to.have.nested.property("[0].auction_number");
+                expect(response).to.have.nested.property("[0].instrument_token");
+                expect(response).to.have.nested.property("[0].tradingsymbol");
                 return done();
             }).catch(done); 
         })


### PR DESCRIPTION
- `getAuctionInstruments` : function for retrieving the auction instruments list.
- ` VARIETY_AUCTION` : order variety
- `auction_number` in placeOrder param
- `test getAuctionInstruments` : unit tests
- update kiteconnect-mocks submodule for new tests added