### PR TITLE
feat: include npm release and docs in gh-pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+
+  publish-doc:
+    runs-on: ubuntu-20.04
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install Dependencies
+        run: |
+          npm install
+          npm install -g jsdoc
+
+      - name: Building documentation for github page
+        run: jsdoc --configure ./.jsdoc.json
+
+      - name: Upload artifacts
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/
+
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -4,7 +4,7 @@
         "dictionaries": ["jsdoc"]
     },
     "source": {
-        "include": ["lib", "package.json", "README.md"],
+        "include": ["lib", "README.md"],
         "includePattern": ".js$",
         "excludePattern": "(node_modules/|docs)"
     },
@@ -21,7 +21,6 @@
         "encoding": "utf8",
         "private": true,
         "recurse": true,
-        "sort": false,
-        "template": "./node_modules/minami"
+        "sort": false
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The official Javascript node client for communicating with the [Kite Connect API
 
 Kite Connect is a set of REST-like APIs that expose many capabilities required to build a complete investment and trading platform. Execute orders in real time, manage user portfolio, stream live market data (WebSockets), and more, with the simple HTTP API collection.
 
-[Zerodha Technology](http://zerodha.com) (c) 2018. Licensed under the MIT License.
+[Zerodha Technology](http://zerodha.com) (c) 2023. Licensed under the MIT License.
 
 ## Documentation
 


### PR DESCRIPTION
- Implemented a new `Deploy.publish-npm` workflow for releasing the new npm package with the tag release.
- Implemented a new `Deploy.publish-doc`  workflow for updating client doc with the new release.

Sample doc can be referred to here:  https://ranjanrak.github.io/kiteconnectjs/