### PR TITLE
Fix for content-type header with charset

### DIFF
--- a/lib/connect.ts
+++ b/lib/connect.ts
@@ -255,7 +255,7 @@ export class KiteConnect implements KiteConnectInterface {
             if (this.debug) console.log(response);
 
             const contentType = response.headers['content-type'];
-            if (contentType === 'application/json' && typeof response.data === 'object') {
+            if (contentType?.includes('application/json') && typeof response.data === 'object') {
                 // Throw incase of error
                 if (response.data.error_type) throw response.data;
 


### PR DESCRIPTION
Issue with content-type header with kiteconnect@5.0.1 where the content-type header is application/json;charset=utf8 which breaks responses.