### PR TITLE
fix: add missing type definitions for market_protection and KiteTickerParams root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Kite v5 - TypeScript
 
+## [5.2.1] - 2026-04-14
+
+### Bug Fixes
+
+- **Type Definitions**: Added missing `market_protection` parameter to `placeOrder` and `modifyOrder` method signatures in `types/connect.d.ts` to keep them in sync with `interfaces/connect.ts` (added in 5.2.0)
+- **Type Definitions**: Added missing `root` parameter to `KiteTickerParams` in `types/ticker.d.ts` to match the internal `interfaces/ticker.ts` definition and the runtime implementation
+
 ## [5.2.0] - 2026-03-27
 
 ### New Features
@@ -72,6 +79,7 @@ If you are upgrading from a previous version, please review the following change
 
 - This release marks a significant update with the transition to TypeScript. Please report any issues or bugs to the repository's issue tracker.
 
+[5.2.1]: https://github.com/zerodha/kiteconnectjs/releases/tag/v5.2.1
 [5.2.0]: https://github.com/zerodha/kiteconnectjs/releases/tag/v5.2.0
 [5.1.0]: https://github.com/zerodha/kiteconnectjs/releases/tag/v5.1.0
 [5.0.0]: https://github.com/zerodha/kiteconnectjs/releases/tag/v5.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kiteconnect",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kiteconnect",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiteconnect",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "The official typescript client for the Kite Connect trading APIs",
   "main": "./dist/lib/index.js",
   "types": "./types/index.d.ts",

--- a/types/connect.d.ts
+++ b/types/connect.d.ts
@@ -2007,6 +2007,10 @@ export type Connect = {
        * Parent order id incase of multilegged orders.
        */
       parent_order_id?: string;
+      /**
+       * Market protection percentage. Set to -1 for system-default, or a percentage value > 0 up to 100.
+       */
+      market_protection?: number;
     }
   ) => Promise<{ order_id: string }>;
 
@@ -2190,6 +2194,10 @@ export type Connect = {
        * An optional tag to apply to an order to identify it (alphanumeric, max 20 chars)
        */
       tag?: string;
+      /**
+       * Market protection percentage. Set to -1 for system-default, or a percentage value > 0 up to 100.
+       */
+      market_protection?: number;
     }
   ) => Promise<{ order_id: string }>;
 

--- a/types/ticker.d.ts
+++ b/types/ticker.d.ts
@@ -21,6 +21,10 @@ export type KiteTickerParams = {
    * in seconds is the maximum delay after which subsequent re-connection interval will become constant. Defaults to 60s and minimum acceptable value is 5s.
    */
   max_delay?: number;
+  /**
+   * WebSocket root endpoint. Defaults to 'wss://ws.kite.trade/'.
+   */
+  root?: string;
 };
   
 export type Ticker = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,6 +777,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
This PR fixes two missing type definitions in the published `.d.ts` files that were left out of sync with their internal interfaces.

**Fix 1 — `market_protection` in `placeOrder` and `modifyOrder` (`types/connect.d.ts`)**

`market_protection` was added to `interfaces/connect.ts` (`PlaceOrderParams` and `ModifyOrderParams`) in #118, but the inline param types in `types/connect.d.ts` were not updated. TypeScript consumers who pass `market_protection` get a type error even though the runtime accepts it.

**Fix 2 — `root` in `KiteTickerParams` (`types/ticker.d.ts`)**

`root` is already in `interfaces/ticker.ts` and read by `lib/ticker.ts` (`params.root || 'wss://ws.kite.trade/'`), but was missing from the published `types/ticker.d.ts`, causing a type error for consumers who pass a custom WebSocket endpoint.