### PR TITLE
feat(order): add algo_id to order params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Kite v5 - TypeScript
 
+## [5.3.1] - 2026-07-23
+
+### New Features
+
+- **Algo ID**: Added optional `algo_id` parameter to `PlaceOrderParams` to associate an algo ID with an order
+
 ## [5.3.0] - 2026-04-23
 
 ### New Features
@@ -101,6 +107,7 @@ If you are upgrading from a previous version, please review the following change
 
 - This release marks a significant update with the transition to TypeScript. Please report any issues or bugs to the repository's issue tracker.
 
+[5.3.1]: https://github.com/zerodha/kiteconnectjs/releases/tag/v5.3.1
 [5.3.0]: https://github.com/zerodha/kiteconnectjs/releases/tag/v5.3.0
 [5.2.0]: https://github.com/zerodha/kiteconnectjs/releases/tag/v5.2.0
 [5.1.0]: https://github.com/zerodha/kiteconnectjs/releases/tag/v5.1.0

--- a/interfaces/connect.ts
+++ b/interfaces/connect.ts
@@ -821,6 +821,10 @@ export interface PlaceOrderParams {
     /**
      * @type {?string}
      */
+    algo_id?: string;
+    /**
+     * @type {?string}
+     */
     tag?: string;
 };
 

--- a/interfaces/connect.ts
+++ b/interfaces/connect.ts
@@ -819,6 +819,7 @@ export interface PlaceOrderParams {
      */
     autoslice?: boolean;
     /**
+     * An optional algo ID to associate with the order.
      * @type {?string}
      */
     algo_id?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kiteconnect",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kiteconnect",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiteconnect",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "The official typescript client for the Kite Connect trading APIs",
   "main": "./dist/lib/index.js",
   "types": "./types/index.d.ts",

--- a/test/test.ts
+++ b/test/test.ts
@@ -48,6 +48,10 @@ function testSuite(){
       .post('/orders/test')
       .reply(200, parseJson('order_response.json'))
 
+      // placeOrder with algo_id
+      .post('/orders/test', /algo_id=algo-123/)
+      .reply(200, parseJson('order_response.json'))
+
       // placeOrder with autoslice
       .post('/orders/regular', /autoslice=true/)
       .reply(200, parseJson('autoslice_response.json'))
@@ -257,6 +261,23 @@ function testSuite(){
                 'product': Products.MIS,
                 'order_type': OrderTypes.MARKET,
                 'market_protection': MarketProtections.AUTO})
+            .then(function(response: AnyObject) {
+                expect(response).to.have.property('order_id');
+                return done();
+            }).catch(done);
+        })
+    });
+
+    describe('placeOrder with algo_id', function() {
+        it('Place market order with algo_id', (done) => {
+            kc.placeOrder(Varieties.TEST, {
+                'exchange': Exchanges.NSE,
+                'tradingsymbol': 'SBIN',
+                'transaction_type': TransactionTypes.BUY,
+                'quantity': 1,
+                'product': Products.MIS,
+                'order_type': OrderTypes.MARKET,
+                'algo_id': 'algo-123'})
             .then(function(response: AnyObject) {
                 expect(response).to.have.property('order_id');
                 return done();

--- a/types/connect.d.ts
+++ b/types/connect.d.ts
@@ -2210,6 +2210,10 @@ export type Connect = {
        */
       auction_number?: number;
       /**
+       * An optional algo ID to associate with the order
+       */
+      algo_id?: string;
+      /**
        * An optional tag to apply to an order to identify it (alphanumeric, max 20 chars)
        */
       tag?: string;


### PR DESCRIPTION
Mirrors zerodha/gokiteconnect#128 by adding algo_id support to order params.